### PR TITLE
Task 7 - Lambda Authorizer

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -31,13 +31,15 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
+    const authorizationToken = localStorage.getItem('authorization_token');
       // Get the presigned URL
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
-        }
+        },
+        headers: authorizationToken ? { Authorization: 'Basic ' + authorizationToken } : undefined
       });
       console.log('File to upload: ', file.name);
       console.log('Uploading to: ', response.data.url);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,13 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error?.response?.status === 400) {
+    const responseStatus = error?.response?.status;
+    if (responseStatus === 400) {
       alert(error.response.data?.data);
+    }
+
+    if (responseStatus === 403 || responseStatus === 401) {
+      alert(error.response.data?.message);
     }
 
     return Promise.reject(error?.response ?? error);


### PR DESCRIPTION
[Task description](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md)

React App URL [here](https://d379rlacz383fa.cloudfront.net/)

[Link to pull request in BE repository](https://github.com/mary725/nodejs-aws-be/pull/5)

importProductsFile URL: https://0pw9gt8mf5.execute-api.us-east-1.amazonaws.com/dev/import

What was done:

- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

Additional tasks

- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file
- [ ] Add Login page and protect getProducts lambda by the Cognito Authorizer
